### PR TITLE
Add PropertyBuilder.HasValueFormatter defaultValue option

### DIFF
--- a/src/Blazor.FlexGrid/Components/Configuration/Builders/InternalPropertyBuilder.cs
+++ b/src/Blazor.FlexGrid/Components/Configuration/Builders/InternalPropertyBuilder.cs
@@ -30,8 +30,8 @@ namespace Blazor.FlexGrid.Components.Configuration.Builders
         public bool HasOrder(int order)
             => HasAnnotation(GridViewAnnotationNames.ColumnOrder, order);
 
-        public bool HasValueFormatter<TProperty>(Expression<Func<TProperty, string>> valueFormatterExpression, bool allowNull = false)
-            => HasAnnotation(GridViewAnnotationNames.ColumnValueFormatter, new ValueFormatter<TProperty>(valueFormatterExpression, allowNull: allowNull));
+        public bool HasValueFormatter<TProperty>(Expression<Func<TProperty, string>> valueFormatterExpression, string defaultValue = default)
+            => HasAnnotation(GridViewAnnotationNames.ColumnValueFormatter, new ValueFormatter<TProperty>(valueFormatterExpression, defaultValue: defaultValue));
 
         public bool HasCompositeValueFormatter<TInputValue>(Expression<Func<TInputValue, string>> valueFormatterExpression)
             => HasAnnotation(GridViewAnnotationNames.ColumnValueFormatter, new ValueFormatter<TInputValue>(valueFormatterExpression, ValueFormatterType.WholeRowObject));

--- a/src/Blazor.FlexGrid/Components/Configuration/Builders/InternalPropertyBuilder.cs
+++ b/src/Blazor.FlexGrid/Components/Configuration/Builders/InternalPropertyBuilder.cs
@@ -30,8 +30,8 @@ namespace Blazor.FlexGrid.Components.Configuration.Builders
         public bool HasOrder(int order)
             => HasAnnotation(GridViewAnnotationNames.ColumnOrder, order);
 
-        public bool HasValueFormatter<TProperty>(Expression<Func<TProperty, string>> valueFormatterExpression)
-            => HasAnnotation(GridViewAnnotationNames.ColumnValueFormatter, new ValueFormatter<TProperty>(valueFormatterExpression));
+        public bool HasValueFormatter<TProperty>(Expression<Func<TProperty, string>> valueFormatterExpression, bool allowNull = false)
+            => HasAnnotation(GridViewAnnotationNames.ColumnValueFormatter, new ValueFormatter<TProperty>(valueFormatterExpression, allowNull: allowNull));
 
         public bool HasCompositeValueFormatter<TInputValue>(Expression<Func<TInputValue, string>> valueFormatterExpression)
             => HasAnnotation(GridViewAnnotationNames.ColumnValueFormatter, new ValueFormatter<TInputValue>(valueFormatterExpression, ValueFormatterType.WholeRowObject));

--- a/src/Blazor.FlexGrid/Components/Configuration/Builders/PropertyBuilder.cs
+++ b/src/Blazor.FlexGrid/Components/Configuration/Builders/PropertyBuilder.cs
@@ -48,6 +48,13 @@ namespace Blazor.FlexGrid.Components.Configuration.Builders
             return this;
         }
 
+        public PropertyBuilder<TProperty, TEntity> HasValueFormatter(Expression<Func<TProperty, string>> valueFormatterExpression, bool allowNull)
+        {
+            Builder.HasValueFormatter(valueFormatterExpression, allowNull);
+
+            return this;
+        }
+
         public PropertyBuilder<TProperty, TEntity> HasCompositeValueFormatter(Expression<Func<TEntity, string>> valueFormatterExpression)
         {
             Builder.HasCompositeValueFormatter(valueFormatterExpression);

--- a/src/Blazor.FlexGrid/Components/Configuration/Builders/PropertyBuilder.cs
+++ b/src/Blazor.FlexGrid/Components/Configuration/Builders/PropertyBuilder.cs
@@ -48,9 +48,9 @@ namespace Blazor.FlexGrid.Components.Configuration.Builders
             return this;
         }
 
-        public PropertyBuilder<TProperty, TEntity> HasValueFormatter(Expression<Func<TProperty, string>> valueFormatterExpression, bool allowNull)
+        public PropertyBuilder<TProperty, TEntity> HasValueFormatter(Expression<Func<TProperty, string>> valueFormatterExpression, string defaultValue)
         {
-            Builder.HasValueFormatter(valueFormatterExpression, allowNull);
+            Builder.HasValueFormatter(valueFormatterExpression, defaultValue);
 
             return this;
         }

--- a/src/Blazor.FlexGrid/Components/Configuration/ValueFormatters/ValueFormatter`.cs
+++ b/src/Blazor.FlexGrid/Components/Configuration/ValueFormatters/ValueFormatter`.cs
@@ -11,15 +11,20 @@ namespace Blazor.FlexGrid.Components.Configuration.ValueFormatters
             => (Expression<Func<TInputValue, string>>)base.FormatValueExpression;
 
 
-        public ValueFormatter(Expression<Func<TInputValue, string>> formatValueExpression, ValueFormatterType valueFormatterType = ValueFormatterType.SingleProperty)
+        public ValueFormatter(Expression<Func<TInputValue, string>> formatValueExpression, ValueFormatterType valueFormatterType = ValueFormatterType.SingleProperty, bool allowNull = false)
             : base(formatValueExpression, valueFormatterType)
         {
-            FormatValue = SanitizeConverter(formatValueExpression);
+            FormatValue = SanitizeConverter(formatValueExpression, allowNull);
         }
 
-        private Func<object, string> SanitizeConverter(Expression<Func<TInputValue, string>> formatValueExpression)
+        private Func<object, string> SanitizeConverter(Expression<Func<TInputValue, string>> formatValueExpression, bool allowNull)
         {
             var compiled = formatValueExpression.Compile();
+
+            if (allowNull)
+            {
+                return v => compiled((TInputValue)v);
+            }
 
             return v => v == null
                 ? string.Empty

--- a/src/Blazor.FlexGrid/Components/Configuration/ValueFormatters/ValueFormatter`.cs
+++ b/src/Blazor.FlexGrid/Components/Configuration/ValueFormatters/ValueFormatter`.cs
@@ -11,23 +11,18 @@ namespace Blazor.FlexGrid.Components.Configuration.ValueFormatters
             => (Expression<Func<TInputValue, string>>)base.FormatValueExpression;
 
 
-        public ValueFormatter(Expression<Func<TInputValue, string>> formatValueExpression, ValueFormatterType valueFormatterType = ValueFormatterType.SingleProperty, bool allowNull = false)
+        public ValueFormatter(Expression<Func<TInputValue, string>> formatValueExpression, ValueFormatterType valueFormatterType = ValueFormatterType.SingleProperty, string defaultValue = default)
             : base(formatValueExpression, valueFormatterType)
         {
-            FormatValue = SanitizeConverter(formatValueExpression, allowNull);
+            FormatValue = SanitizeConverter(formatValueExpression, defaultValue);
         }
 
-        private Func<object, string> SanitizeConverter(Expression<Func<TInputValue, string>> formatValueExpression, bool allowNull)
+        private Func<object, string> SanitizeConverter(Expression<Func<TInputValue, string>> formatValueExpression, string defaultValue)
         {
             var compiled = formatValueExpression.Compile();
 
-            if (allowNull)
-            {
-                return v => compiled((TInputValue)v);
-            }
-
             return v => v == null
-                ? string.Empty
+                ? defaultValue ?? string.Empty
                 : compiled((TInputValue)v);
         }
     }


### PR DESCRIPTION
Added option to allow null for `PropertyBuilder.HasValueFormatter`.

Example:

```cs
builder.Property(e => e.property)
    .HasValueFormatter(e => e != null ? e.ToString() : "Null", true);
```