### PR TITLE
Master/Detail table: fix bug with nullable member types 

### DIFF
--- a/src/Blazor.FlexGrid/Components/Configuration/Builders/EntityTypeBuilder.cs
+++ b/src/Blazor.FlexGrid/Components/Configuration/Builders/EntityTypeBuilder.cs
@@ -50,6 +50,15 @@ namespace Blazor.FlexGrid.Components.Configuration.Builders
             return this;
         }
 
+        public virtual EntityTypeBuilder<TEntity> IsMasterTable(Action<MasterDetailOptions> configureMasterDetails)
+        {
+            var masterDetails = new MasterDetailOptions();
+            configureMasterDetails?.Invoke(masterDetails);
+            Builder.IsMasterTable(masterDetails);
+            
+            return this;
+        }
+
         public virtual EntityTypeBuilder<TEntity> AllowInlineEdit()
         {
             Builder.AllowInlineEdit(new InlineEditOptions());
@@ -91,10 +100,10 @@ namespace Blazor.FlexGrid.Components.Configuration.Builders
             return this;
         }
 
-        public virtual EntityTypeBuilder<TEntity> OnlyShowExplicitDetailTables()
-        {
-            Builder.Metadata.OnlyShowExplicitDetailTables = true;
-            return this;
-        }
+        //public virtual EntityTypeBuilder<TEntity> OnlyShowExplicitDetailTables()
+        //{
+        //    Builder.Metadata.OnlyShowExplicitDetailTables = true;
+        //    return this;
+        //}
     }
 }

--- a/src/Blazor.FlexGrid/Components/Configuration/Builders/EntityTypeBuilder.cs
+++ b/src/Blazor.FlexGrid/Components/Configuration/Builders/EntityTypeBuilder.cs
@@ -90,5 +90,11 @@ namespace Blazor.FlexGrid.Components.Configuration.Builders
 
             return this;
         }
+
+        public virtual EntityTypeBuilder<TEntity> OnlyShowExplicitDetailTables()
+        {
+            Builder.Metadata.OnlyShowExplicitDetailTables = true;
+            return this;
+        }
     }
 }

--- a/src/Blazor.FlexGrid/Components/Configuration/Builders/InternalEntityTypeBuilder.cs
+++ b/src/Blazor.FlexGrid/Components/Configuration/Builders/InternalEntityTypeBuilder.cs
@@ -63,5 +63,7 @@ namespace Blazor.FlexGrid.Components.Configuration.Builders
 
         public bool AllowCreateItem(CreateItemOptions createItemOptions)
             => HasAnnotation(GridViewAnnotationNames.CreateItemOptions, createItemOptions);
+
+        
     }
 }

--- a/src/Blazor.FlexGrid/Components/Configuration/Builders/InternalEntityTypeBuilder.cs
+++ b/src/Blazor.FlexGrid/Components/Configuration/Builders/InternalEntityTypeBuilder.cs
@@ -57,6 +57,12 @@ namespace Blazor.FlexGrid.Components.Configuration.Builders
         public bool IsMasterTable()
             => HasAnnotation(GridViewAnnotationNames.IsMasterTable, true);
 
+        public bool IsMasterTable(MasterDetailOptions masterDetailOptions)
+        {
+            IsMasterTable();
+            return HasAnnotation(GridViewAnnotationNames.MasterDetailOptions, masterDetailOptions);
+        }
+
 
         public bool AllowInlineEdit(InlineEditOptions inlineEditOptions)
             => HasAnnotation(GridViewAnnotationNames.InlineEditOptions, inlineEditOptions);

--- a/src/Blazor.FlexGrid/Components/Configuration/GridViewAnnotationNames.cs
+++ b/src/Blazor.FlexGrid/Components/Configuration/GridViewAnnotationNames.cs
@@ -12,6 +12,7 @@
         public const string DetailDeleteUrl = "DetailDeleteUrl";
         public const string InlineEditOptions = "InlineEditOptions";
         public const string CreateItemOptions = "CreateItemOptions";
+        public const string MasterDetailOptions = "MasterDetailOptions";
 
         public const string ColumnHeaderStyle = "GridColumnHeaderStyle";
         public const string ColumnCaption = "GridColumnCaption";

--- a/src/Blazor.FlexGrid/Components/Configuration/MasterDetailOptions.cs
+++ b/src/Blazor.FlexGrid/Components/Configuration/MasterDetailOptions.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Blazor.FlexGrid.Components.Configuration
+{
+    public class MasterDetailOptions
+    {
+
+        public bool OnlyShowExplicitDetailTables
+        {
+            get; set;
+        }
+
+    }
+}

--- a/src/Blazor.FlexGrid/Components/Configuration/MasterDetailOptions.cs
+++ b/src/Blazor.FlexGrid/Components/Configuration/MasterDetailOptions.cs
@@ -7,10 +7,13 @@ namespace Blazor.FlexGrid.Components.Configuration
     public class MasterDetailOptions
     {
 
-        public bool OnlyShowExplicitDetailTables
-        {
-            get; set;
-        }
+        public bool OnlyShowExplicitDetailTables { get; set; }
 
     }
+
+    public class NullMasterDetailOptions: MasterDetailOptions
+    {
+
+    }
+
 }

--- a/src/Blazor.FlexGrid/Components/Configuration/MetaData/EntityType.cs
+++ b/src/Blazor.FlexGrid/Components/Configuration/MetaData/EntityType.cs
@@ -17,6 +17,9 @@ namespace Blazor.FlexGrid.Components.Configuration.MetaData
 
         public IReadOnlyCollection<PropertyInfo> ClrTypeCollectionProperties { get; }
 
+        public bool OnlyShowExplicitDetailTables { get; set; } = false;
+
+
         public EntityType(Type clrType, Model model)
         {
             Model = model ?? throw new ArgumentNullException(nameof(model));

--- a/src/Blazor.FlexGrid/Components/Configuration/MetaData/EntityType.cs
+++ b/src/Blazor.FlexGrid/Components/Configuration/MetaData/EntityType.cs
@@ -16,9 +16,7 @@ namespace Blazor.FlexGrid.Components.Configuration.MetaData
         public string Name { get; }
 
         public IReadOnlyCollection<PropertyInfo> ClrTypeCollectionProperties { get; }
-
-        public bool OnlyShowExplicitDetailTables { get; set; } = false;
-
+        
 
         public EntityType(Type clrType, Model model)
         {

--- a/src/Blazor.FlexGrid/Components/Configuration/MetaData/GridAnotations.cs
+++ b/src/Blazor.FlexGrid/Components/Configuration/MetaData/GridAnotations.cs
@@ -22,11 +22,14 @@ namespace Blazor.FlexGrid.Components.Configuration.MetaData
             }
         }
 
-        public bool OnlyShowExplicitDetailTables
+        
+        public MasterDetailOptions MasterDetailOptions
         {
             get
             {
-                return entityTypeMetadata.OnlyShowExplicitDetailTables;
+                var masterDetailOptions = annotations[GridViewAnnotationNames.MasterDetailOptions];
+                
+                return (MasterDetailOptions)masterDetailOptions;
             }
         }
 

--- a/src/Blazor.FlexGrid/Components/Configuration/MetaData/GridAnotations.cs
+++ b/src/Blazor.FlexGrid/Components/Configuration/MetaData/GridAnotations.cs
@@ -28,7 +28,11 @@ namespace Blazor.FlexGrid.Components.Configuration.MetaData
             get
             {
                 var masterDetailOptions = annotations[GridViewAnnotationNames.MasterDetailOptions];
-                
+                if (masterDetailOptions is NullAnotationValue)
+                {
+                    return new NullMasterDetailOptions();
+                }
+
                 return (MasterDetailOptions)masterDetailOptions;
             }
         }

--- a/src/Blazor.FlexGrid/Components/Configuration/MetaData/GridAnotations.cs
+++ b/src/Blazor.FlexGrid/Components/Configuration/MetaData/GridAnotations.cs
@@ -22,6 +22,14 @@ namespace Blazor.FlexGrid.Components.Configuration.MetaData
             }
         }
 
+        public bool OnlyShowExplicitDetailTables
+        {
+            get
+            {
+                return entityTypeMetadata.OnlyShowExplicitDetailTables;
+            }
+        }
+
         public GridCssClasses CssClasses
         {
             get
@@ -64,6 +72,8 @@ namespace Blazor.FlexGrid.Components.Configuration.MetaData
                 return (CreateItemOptions)createItemOptions;
             }
         }
+
+        
 
         public GridAnotations(IEntityType entityType)
         {

--- a/src/Blazor.FlexGrid/Components/Configuration/MetaData/IEntityType.cs
+++ b/src/Blazor.FlexGrid/Components/Configuration/MetaData/IEntityType.cs
@@ -14,6 +14,9 @@ namespace Blazor.FlexGrid.Components.Configuration.MetaData
 
         IReadOnlyCollection<PropertyInfo> ClrTypeCollectionProperties { get; }
 
+        bool OnlyShowExplicitDetailTables { get; set; }
+
+
         IEnumerable<IProperty> GetProperties();
 
         IProperty FindProperty(string name);

--- a/src/Blazor.FlexGrid/Components/Configuration/MetaData/IEntityType.cs
+++ b/src/Blazor.FlexGrid/Components/Configuration/MetaData/IEntityType.cs
@@ -14,9 +14,7 @@ namespace Blazor.FlexGrid.Components.Configuration.MetaData
 
         IReadOnlyCollection<PropertyInfo> ClrTypeCollectionProperties { get; }
 
-        bool OnlyShowExplicitDetailTables { get; set; }
-
-
+        
         IEnumerable<IProperty> GetProperties();
 
         IProperty FindProperty(string name);

--- a/src/Blazor.FlexGrid/Components/Configuration/MetaData/IGridViewAnotations.cs
+++ b/src/Blazor.FlexGrid/Components/Configuration/MetaData/IGridViewAnotations.cs
@@ -5,10 +5,10 @@ namespace Blazor.FlexGrid.Components.Configuration.MetaData
     public interface IGridViewAnotations
     {
         bool IsMasterTable { get; }
-
-        bool OnlyShowExplicitDetailTables { get; }
-
+        
         InlineEditOptions InlineEditOptions { get; }
+
+        MasterDetailOptions MasterDetailOptions { get; }
 
         CreateItemOptions CreateItemOptions { get; }
 

--- a/src/Blazor.FlexGrid/Components/Configuration/MetaData/IGridViewAnotations.cs
+++ b/src/Blazor.FlexGrid/Components/Configuration/MetaData/IGridViewAnotations.cs
@@ -6,6 +6,8 @@ namespace Blazor.FlexGrid.Components.Configuration.MetaData
     {
         bool IsMasterTable { get; }
 
+        bool OnlyShowExplicitDetailTables { get; }
+
         InlineEditOptions InlineEditOptions { get; }
 
         CreateItemOptions CreateItemOptions { get; }

--- a/src/Blazor.FlexGrid/Components/Configuration/MetaData/NullEntityType.cs
+++ b/src/Blazor.FlexGrid/Components/Configuration/MetaData/NullEntityType.cs
@@ -19,8 +19,6 @@ namespace Blazor.FlexGrid.Components.Configuration.MetaData
         public IReadOnlyCollection<PropertyInfo> ClrTypeCollectionProperties => new List<PropertyInfo>();
 
 
-        public bool OnlyShowExplicitDetailTables { get; set; } = false;
-
         public IProperty AddProperty(MemberInfo memberInfo)
         {
             return null;

--- a/src/Blazor.FlexGrid/Components/Configuration/MetaData/NullEntityType.cs
+++ b/src/Blazor.FlexGrid/Components/Configuration/MetaData/NullEntityType.cs
@@ -18,6 +18,9 @@ namespace Blazor.FlexGrid.Components.Configuration.MetaData
 
         public IReadOnlyCollection<PropertyInfo> ClrTypeCollectionProperties => new List<PropertyInfo>();
 
+
+        public bool OnlyShowExplicitDetailTables { get; set; } = false;
+
         public IProperty AddProperty(MemberInfo memberInfo)
         {
             return null;

--- a/src/Blazor.FlexGrid/Components/Renderers/GridTabControlRenderer.cs
+++ b/src/Blazor.FlexGrid/Components/Renderers/GridTabControlRenderer.cs
@@ -59,6 +59,7 @@ namespace Blazor.FlexGrid.Components.Renderers
                 RenderTab(rendererContext, masterTableDataSet, selectedDataAdapter, dataAdapter);
             }
 
+            if (!rendererContext.GridConfiguration.OnlyShowExplicitDetailTables)
             foreach (var collectionProperty in rendererContext.GridItemCollectionProperties)
             {
                 if (permissionContext.HasCurrentUserReadPermission(collectionProperty.Name))

--- a/src/Blazor.FlexGrid/Components/Renderers/GridTabControlRenderer.cs
+++ b/src/Blazor.FlexGrid/Components/Renderers/GridTabControlRenderer.cs
@@ -59,7 +59,7 @@ namespace Blazor.FlexGrid.Components.Renderers
                 RenderTab(rendererContext, masterTableDataSet, selectedDataAdapter, dataAdapter);
             }
 
-            if (!rendererContext.GridConfiguration.OnlyShowExplicitDetailTables)
+            if (!rendererContext.GridConfiguration.MasterDetailOptions.OnlyShowExplicitDetailTables)
             foreach (var collectionProperty in rendererContext.GridItemCollectionProperties)
             {
                 if (permissionContext.HasCurrentUserReadPermission(collectionProperty.Name))

--- a/src/Blazor.FlexGrid/DataAdapters/Visitors/FilterVisitor.cs
+++ b/src/Blazor.FlexGrid/DataAdapters/Visitors/FilterVisitor.cs
@@ -36,10 +36,18 @@ namespace Blazor.FlexGrid.DataAdapters.Visitors
 
                 var parameter = Expression.Parameter(detailAdapterItemType, "x");
                 var member = Expression.Property(parameter, masterDetailRelationship.MasterDetailConnection.ForeignPropertyName);
-                var constant = Expression.Constant(constantValue);
+
+                //If the type of the member expression is a nullable,
+                //the call to Expression.Equal will fail
+                Expression constant;
+                if (member.Type.IsGenericType && member.Type.GetGenericTypeDefinition() == typeof(Nullable<>))
+                    constant = Expression.Constant(constantValue, member.Type);
+                else
+                    constant = Expression.Constant(constantValue);
+
                 var body = Expression.Equal(member, constant);
 
-                collectionTableDataAdapter.Filter = Expression.Lambda<Func<TItem, bool>>(body, parameter); ;
+                collectionTableDataAdapter.Filter = Expression.Lambda<Func<TItem, bool>>(body, parameter); 
             }
         }
     }


### PR DESCRIPTION
I've added a fix to a bug I've encountered within the method Visit of the FilterVisitor class: when building the Filter expression, initializing the "body" local variable would lead to an error if "member" corresponded to a nullable type, since in this case the "constant" expression would not correspond to a nullable type, hence a mismatch between "member" and "constant".

Besides, I've also added a configuration method "OnlyShowExplicitDetailTables()" for EntityTypeBuilder: when it is called, a click on a row in a master table only toggles detail tables for which a call to "HasDetailRelationship()" has been made in the grid configuration class. This is useful when dealing with data classes with dozens of properties - hence dozens of collection properties that you don't want to display by default.  